### PR TITLE
Add credential chaining

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,12 +15,13 @@
   version = "1.1"
 
 [[projects]]
-  digest = "1:73d72ad4ed3ffc0ae85442ff1ce0884423efa6c666566c13d90d75242a038f85"
+  digest = "1:cde027e8bb29425770dd8ddc87789e0139f2dc53a80e248c8d6a0698c7e3f0bc"
   name = "github.com/aliyun/alibaba-cloud-sdk-go"
   packages = [
     "sdk",
     "sdk/auth",
     "sdk/auth/credentials",
+    "sdk/auth/credentials/providers",
     "sdk/auth/signers",
     "sdk/endpoints",
     "sdk/errors",
@@ -30,8 +31,8 @@
     "services/sts",
   ]
   pruneopts = "UT"
-  revision = "0e5371c0881225da7ef9f41ca50402a025eddd93"
-  version = "1.25.5"
+  revision = "ef9535c490beb6b59620d93f6c7ba88e9b3b1ad0"
+  version = "1.26.2"
 
 [[projects]]
   branch = "master"
@@ -406,7 +407,8 @@
   analyzer-version = 1
   input-imports = [
     "github.com/aliyun/alibaba-cloud-sdk-go/sdk",
-    "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials",
+    "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth",
+    "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers",
     "github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints",
     "github.com/aliyun/alibaba-cloud-sdk-go/services/sts",
     "github.com/hashicorp/errwrap",

--- a/backend_test.go
+++ b/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault-plugin-auth-alicloud/tools"
 	"github.com/hashicorp/vault/logical"
@@ -207,7 +208,16 @@ func ListOfOne(t *testing.T) {
 }
 
 func LoginSuccess(t *testing.T) {
-	data, err := tools.GenerateLoginData("accessKeyID", "accessKeySecret", "securityToken", "us-west-2")
+	creds, err := providers.NewConfigurationCredentialProvider(&providers.Configuration{
+		AccessKeyID:       "accessKeyID",
+		AccessKeySecret:   "accessKeySecret",
+		AccessKeyStsToken: "securityToken",
+	}).Retrieve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := tools.GenerateLoginData(creds, "us-west-2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend_test.go
+++ b/backend_test.go
@@ -217,7 +217,7 @@ func LoginSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := tools.GenerateLoginData(creds, "us-west-2")
+	data, err := tools.GenerateLoginData("elk", creds, "us-west-2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli.go
+++ b/cli.go
@@ -33,12 +33,11 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		return nil, err
 	}
 
-	loginData, err := tools.GenerateLoginData(creds, m["region"])
+	loginData, err := tools.GenerateLoginData(role, creds, m["region"])
 	if err != nil {
 		return nil, err
 	}
 
-	loginData["role"] = role
 	path := fmt.Sprintf("auth/%s/login", mount)
 
 	secret, err := c.Logical().Write(path, loginData)

--- a/tools/login/login.go
+++ b/tools/login/login.go
@@ -61,7 +61,7 @@ func main() {
 		panic(err)
 	}
 
-	loginData, err := tools.GenerateLoginData(creds, region)
+	loginData, err := tools.GenerateLoginData(roleName, creds, region)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,14 +8,15 @@ import (
 	"net/url"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
 )
 
-// Generates the necessary data to send to the Vault server for generating a token
-// This is useful for other API clients to use
-func GenerateLoginData(accessKeyID, accessKeySecret, securityToken, region string) (map[string]interface{}, error) {
-	creds := credentials.NewStsTokenCredential(accessKeyID, accessKeySecret, securityToken)
+// Generates the necessary data to send to the Vault server for generating a token.
+// This is useful for other API clients to use.
+// If "" is passed in for accessKeyID, accessKeySecret, and securityToken,
+// attempts to use credentials set as env vars or available through instance metadata.
+func GenerateLoginData(creds auth.Credential, region string) (map[string]interface{}, error) {
 
 	config := sdk.NewConfig()
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -16,7 +16,7 @@ import (
 // This is useful for other API clients to use.
 // If "" is passed in for accessKeyID, accessKeySecret, and securityToken,
 // attempts to use credentials set as env vars or available through instance metadata.
-func GenerateLoginData(creds auth.Credential, region string) (map[string]interface{}, error) {
+func GenerateLoginData(role string, creds auth.Credential, region string) (map[string]interface{}, error) {
 
 	config := sdk.NewConfig()
 
@@ -52,6 +52,7 @@ func GenerateLoginData(creds auth.Credential, region string) (map[string]interfa
 	}
 	headers := base64.StdEncoding.EncodeToString(b)
 	return map[string]interface{}{
+		"role":                     role,
 		"identity_request_url":     u,
 		"identity_request_headers": headers,
 	}, nil

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/chain.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/chain.go
@@ -1,0 +1,34 @@
+package providers
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+)
+
+type Provider interface {
+	Retrieve() (auth.Credential, error)
+}
+
+// NewChainProvider will attempt to use its given providers in the order
+// in which they're provided. It will return credentials for the first
+// provider that doesn't return an error.
+func NewChainProvider(providers []Provider) Provider {
+	return &ChainProvider{
+		Providers: providers,
+	}
+}
+
+type ChainProvider struct {
+	Providers []Provider
+}
+
+func (p *ChainProvider) Retrieve() (auth.Credential, error) {
+	var lastErr error
+	for _, provider := range p.Providers {
+		creds, err := provider.Retrieve()
+		if err == nil {
+			return creds, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/configuration.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/configuration.go
@@ -1,0 +1,62 @@
+package providers
+
+import (
+	"errors"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
+)
+
+var (
+	ErrNoValidCredentialsFound = errors.New("no valid credentials were found")
+)
+
+type Configuration struct {
+	AccessKeyID           string
+	AccessKeySecret       string
+	AccessKeyStsToken     string
+	RoleArn               string
+	RoleSessionName       string
+	RoleSessionExpiration *int
+	PrivateKey            string
+	PublicKeyID           string
+	SessionExpiration     *int
+	RoleName              string
+}
+
+func NewConfigurationCredentialProvider(configuration *Configuration) Provider {
+	return &ConfigurationProvider{
+		Configuration: configuration,
+	}
+}
+
+type ConfigurationProvider struct {
+	Configuration *Configuration
+}
+
+// Retrieve walks through all currently supported credential types and attempts to build them
+// using the given configuration.
+func (p *ConfigurationProvider) Retrieve() (auth.Credential, error) {
+
+	if p.Configuration.AccessKeyID != "" && p.Configuration.AccessKeySecret != "" {
+
+		if p.Configuration.RoleArn != "" && p.Configuration.RoleSessionName != "" && p.Configuration.RoleSessionExpiration != nil {
+			return credentials.NewRamRoleArnCredential(p.Configuration.AccessKeyID, p.Configuration.AccessKeySecret, p.Configuration.RoleArn, p.Configuration.RoleSessionName, *p.Configuration.RoleSessionExpiration), nil
+		}
+
+		if p.Configuration.AccessKeyStsToken != "" {
+			return credentials.NewStsTokenCredential(p.Configuration.AccessKeyID, p.Configuration.AccessKeySecret, p.Configuration.AccessKeyStsToken), nil
+		}
+
+		return credentials.NewAccessKeyCredential(p.Configuration.AccessKeyID, p.Configuration.AccessKeySecret), nil
+	}
+
+	if p.Configuration.RoleName != "" {
+		return credentials.NewEcsRamRoleCredential(p.Configuration.RoleName), nil
+	}
+
+	if p.Configuration.PrivateKey != "" && p.Configuration.PublicKeyID != "" && p.Configuration.SessionExpiration != nil {
+		return credentials.NewRsaKeyPairCredential(p.Configuration.PrivateKey, p.Configuration.PublicKeyID, *p.Configuration.SessionExpiration), nil
+	}
+	return nil, ErrNoValidCredentialsFound
+}

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/env.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/env.go
@@ -1,0 +1,65 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+)
+
+const (
+	EnvVarAccessKeyID           = "ALICLOUD_ACCESS_KEY"
+	EnvVarAccessKeySecret       = "ALICLOUD_SECRET_KEY"
+	EnvVarAccessKeyStsToken     = "ALICLOUD_ACCESS_KEY_STS_TOKEN"
+	EnvVarRoleArn               = "ALICLOUD_ROLE_ARN"
+	EnvVarRoleSessionName       = "ALICLOUD_ROLE_SESSION_NAME"
+	EnvVarRoleSessionExpiration = "ALICLOUD_ROLE_SESSION_EXPIRATION"
+	EnvVarPrivateKey            = "ALICLOUD_PRIVATE_KEY"
+	EnvVarPublicKeyID           = "ALICLOUD_PUBLIC_KEY_ID"
+	EnvVarSessionExpiration     = "ALICLOUD_SESSION_EXPIRATION"
+	EnvVarRoleName              = "ALICLOUD_ROLE_NAME"
+)
+
+func NewEnvCredentialProvider() Provider {
+	return &EnvProvider{}
+}
+
+type EnvProvider struct{}
+
+func (p *EnvProvider) Retrieve() (auth.Credential, error) {
+	roleSessionExpiration, err := envVarToInt(EnvVarRoleSessionExpiration)
+	if err != nil {
+		return nil, err
+	}
+	sessionExpiration, err := envVarToInt(EnvVarSessionExpiration)
+	if err != nil {
+		return nil, err
+	}
+	c := &Configuration{
+		AccessKeyID:           os.Getenv(EnvVarAccessKeyID),
+		AccessKeySecret:       os.Getenv(EnvVarAccessKeySecret),
+		AccessKeyStsToken:     os.Getenv(EnvVarAccessKeyStsToken),
+		RoleArn:               os.Getenv(EnvVarRoleArn),
+		RoleSessionName:       os.Getenv(EnvVarRoleSessionName),
+		RoleSessionExpiration: &roleSessionExpiration,
+		PrivateKey:            os.Getenv(EnvVarPrivateKey),
+		PublicKeyID:           os.Getenv(EnvVarPublicKeyID),
+		SessionExpiration:     &sessionExpiration,
+		RoleName:              os.Getenv(EnvVarRoleName),
+	}
+	return NewConfigurationCredentialProvider(c).Retrieve()
+}
+
+func envVarToInt(envVar string) (int, error) {
+	asInt := 0
+	asStr := os.Getenv(envVar)
+	if asStr != "" {
+		if i, err := strconv.Atoi(asStr); err != nil {
+			return 0, fmt.Errorf("error parsing %s: %s", envVar, err)
+		} else {
+			asInt = i
+		}
+	}
+	return asInt, nil
+}

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/instance_metadata.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/providers/instance_metadata.go
@@ -1,0 +1,86 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
+)
+
+var securityCredURL = "http://100.100.100.200/latest/meta-data/ram/security-credentials/"
+
+func NewInstanceMetadataProvider() Provider {
+	return &InstanceMetadataProvider{}
+}
+
+type InstanceMetadataProvider struct {
+	RoleName string
+}
+
+func (p *InstanceMetadataProvider) Retrieve() (auth.Credential, error) {
+	if p.RoleName == "" {
+		// Instances can have only one role name that never changes,
+		// so attempt to populate it.
+		// If this call is executed in an environment that doesn't support instance metadata,
+		// it will time out after 30 seconds and return an err.
+		resp, err := http.Get(securityCredURL)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		if resp.StatusCode != 200 {
+			return nil, fmt.Errorf("received %d getting role name: %s", resp.StatusCode, bodyBytes)
+		}
+		roleName := string(bodyBytes)
+		if roleName == "" {
+			return nil, errors.New("unable to retrieve role name, it may be unset")
+		}
+		p.RoleName = roleName
+	}
+
+	resp, err := http.Get(securityCredURL + p.RoleName)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("received %d getting security credentials for %s", resp.StatusCode, p.RoleName)
+	}
+	body := make(map[string]interface{})
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+
+	accessKeyID, err := extractString(body, "AccessKeyId")
+	if err != nil {
+		return nil, err
+	}
+	accessKeySecret, err := extractString(body, "AccessKeySecret")
+	if err != nil {
+		return nil, err
+	}
+	securityToken, err := extractString(body, "SecurityToken")
+	if err != nil {
+		return nil, err
+	}
+	return credentials.NewStsTokenCredential(accessKeyID, accessKeySecret, securityToken), nil
+}
+
+func extractString(m map[string]interface{}, key string) (string, error) {
+	raw, ok := m[key]
+	if !ok {
+		return "", fmt.Errorf("%s not in %+v", key, m)
+	}
+	str, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s is not a string in %+v", key, m)
+	}
+	return str, nil
+}

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/client.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/client.go
@@ -250,7 +250,9 @@ func (client *Client) DoActionWithSigner(request requests.AcsRequest, response r
 		var timeout bool
 		// receive error
 		if err != nil {
-			if timeout = isTimeout(err); !timeout {
+			if !client.config.AutoRetry {
+				return
+			} else if timeout = isTimeout(err); !timeout {
 				// if not timeout error, return
 				return
 			} else if retryTimes >= client.config.MaxRetryTime {

--- a/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses/response.go
+++ b/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses/response.go
@@ -47,6 +47,11 @@ func Unmarshal(response AcsResponse, httpResponse *http.Response, format string)
 		// common response need not unmarshal
 		return
 	}
+
+	if len(response.GetHttpContentBytes()) == 0 {
+		return
+	}
+
 	if strings.ToUpper(format) == "JSON" {
 		initJsonParserOnce()
 		err = jsonParser.Unmarshal(response.GetHttpContentBytes(), response)


### PR DESCRIPTION
Adds using a credential chain to:
1. The binary you can drop onto an instance and execute a login request with
2. The CLI you can use for generating a login request

Also fixes a minor bug with the role name not being returned with login data. This is workaround-able by creating role names in Vault that match the role name on the arn.