### PR TITLE
Use derived role name

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -114,7 +114,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 				"identity_type": callerIdentity.IdentityType,
 				"principal_id":  callerIdentity.PrincipalId,
 				"request_id":    callerIdentity.RequestId,
-				"role_name":     parsedARN.RoleName,
+				"role_name":     roleName,
 			},
 			DisplayName: callerIdentity.PrincipalId,
 			LeaseOptions: logical.LeaseOptions{


### PR DESCRIPTION
Solves a bug where tokens couldn't be renewed if the role's ARN had a different role name than the name of the role in Vault.