### PR TITLE
Only run a dev build remotely 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
           echo 'export GO111MODULE=on' >> $BASH_ENV
     - run:
         name: "Run Tests"
-        command: go test -v ./...
+        command: make test
     - run:
         name: "Install Gox"
         command: go get github.com/mitchellh/gox
     - run:
         name: "Run Build"
-        command: ./scripts/build.sh
+        command: make dev


### PR DESCRIPTION
Some builds were failing because during the build step, they were using too much memory and causing the Travis container to OOM. This PR only runs one build, rather than many, to preserve memory remotely.