### PR TITLE
Remove gox in favor of go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 TOOL?=vault-plugin-auth-alibaba
 TEST?=$$(go list ./... | grep -v /vendor/ | grep -v teamcity)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
-EXTERNAL_TOOLS=\
-	github.com/mitchellh/gox \
-	github.com/golang/dep/cmd/dep
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
@@ -36,12 +33,6 @@ testcompile: fmtcheck generate
 generate:
 	go generate $(go list ./... | grep -v /vendor/)
 
-# bootstrap the build by downloading additional tools
-bootstrap:
-	@for tool in  $(EXTERNAL_TOOLS) ; do \
-		echo "Installing/Updating $$tool" ; \
-		go get -u $$tool; \
-	done
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
@@ -52,4 +43,4 @@ fmt:
 proto:
 	protoc *.proto --go_out=plugins=grpc:.
 
-.PHONY: bin default generate test vet bootstrap fmt fmtcheck
+.PHONY: bin default generate test vet fmt fmtcheck

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ For local dev first make sure Go is properly installed, including
 setting up a [GOPATH](https://golang.org/doc/code.html#GOPATH).
 Next, clone this repository into
 `$GOPATH/src/github.com/hashicorp/vault-plugin-auth-alicloud`.
-You can then download any required build tools by bootstrapping your
-environment:
-
-```sh
-$ make bootstrap
-```
 
 To compile a development version of this plugin, run `make` or `make dev`.
 This will put the plugin binary in the `bin` and `$GOPATH/bin` folders. `dev`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 TOOL=vault-plugin-auth-alicloud
 #
 # This script builds the application from source for multiple platforms.
-set -ex
+set -e
 
 GO_CMD=${GO_CMD:-go}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,9 @@
 TOOL=vault-plugin-auth-alicloud
 #
 # This script builds the application from source for multiple platforms.
-set -e
+set -ex
+
+GO_CMD=${GO_CMD:-go}
 
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
@@ -20,11 +22,6 @@ BUILD_TAGS="${BUILD_TAGS}:-${TOOL}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
-
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)
@@ -38,52 +35,22 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-# If its dev mode, only build for our self
-if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
-    XC_OS=$(go env GOOS)
-    XC_ARCH=$(go env GOARCH)
-    XC_OSARCH=$(go env GOOS)/$(go env GOARCH)
-fi
-
-# The main method we need for building is in the cmd directory
-cd "${DIR}/cmd/${TOOL}"
-
 # Build!
 echo "==> Building..."
-gox \
-    -osarch="${XC_OSARCH}" \
+${GO_CMD} build \
+    -gcflags "${GCFLAGS}" \
     -ldflags "-X github.com/hashicorp/${TOOL}/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
-    -output "${DIR}/pkg/{{.OS}}_{{.Arch}}/${TOOL}" \
-    -tags="${BUILD_TAGS}" \
-    .
-
-# Return to the home directory
-cd "$DIR"
+    -o "bin/${TOOL}" \
+    -tags "${BUILD_TAGS}" \
+    "${DIR}/cmd/${TOOL}"
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
-# Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
-
-if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
-    # Zip and copy to the dist dir
-    echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
-        OSARCH=$(basename ${PLATFORM})
-        echo "--> ${OSARCH}"
-
-        pushd $PLATFORM >/dev/null 2>&1
-        zip ../${OSARCH}.zip ./*
-        popd >/dev/null 2>&1
-    done
-fi
+rm -f ${MAIN_GOPATH}/bin/${TOOL}
+cp bin/${TOOL} ${MAIN_GOPATH}/bin/
 
 # Done!
 echo


### PR DESCRIPTION
gox is no longer maintained and releases are done with `go build` now. See https://github.com/hashicorp/vault/pull/16353 where we removed gox in Vault.