### PR TITLE
Enable acceptance test github action workflow

### DIFF
--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -1,0 +1,22 @@
+name: Run Acceptance Tests
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  run-acc-tests:
+    runs-on: ubuntu-latest
+    steps:
+      env:
+        VAULT_ACC_TEST_ROLE_ARN: ${{ secrets.VAULT_ACC_TEST_ROLE_ARN }}
+        VAULT_ACC_TEST_ACCESS_KEY_ID: ${{ secrets.VAULT_ACC_TEST_ACCESS_KEY_ID }}
+        VAULT_ACC_TEST_SECRET_KEY: ${{ secrets.VAULT_ACC_TEST_SECRET_KEY }}
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: .go-version
+          cache: true
+      - name: Run Acceptance Tests
+        run: make testacc

--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -8,15 +8,15 @@ permissions:
 jobs:
   run-acc-tests:
     runs-on: ubuntu-latest
+    env:
+      VAULT_ACC_TEST_ROLE_ARN: ${{ secrets.VAULT_ACC_TEST_ROLE_ARN }}
+      VAULT_ACC_TEST_ACCESS_KEY_ID: ${{ secrets.VAULT_ACC_TEST_ACCESS_KEY_ID }}
+      VAULT_ACC_TEST_SECRET_KEY: ${{ secrets.VAULT_ACC_TEST_SECRET_KEY }}
     steps:
-      env:
-        VAULT_ACC_TEST_ROLE_ARN: ${{ secrets.VAULT_ACC_TEST_ROLE_ARN }}
-        VAULT_ACC_TEST_ACCESS_KEY_ID: ${{ secrets.VAULT_ACC_TEST_ACCESS_KEY_ID }}
-        VAULT_ACC_TEST_SECRET_KEY: ${{ secrets.VAULT_ACC_TEST_SECRET_KEY }}
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version-file: .go-version
-          cache: true
-      - name: Run Acceptance Tests
-        run: make testacc
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      with:
+        go-version-file: .go-version
+        cache: true
+    - name: Run Acceptance Tests
+      run: make testacc

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ testshort: fmtcheck generate
 test: fmtcheck generate
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
 
+# testacc runs the acceptance tests and vets the code
+testacc: fmtcheck generate
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \
 		go test -v -c -tags='$(BUILD_TAGS)' $$pkg -parallel=4 ; \

--- a/README.md
+++ b/README.md
@@ -117,3 +117,27 @@ You can also specify a `TESTARGS` variable to filter tests like so:
 ```sh
 $ make test TESTARGS='--run=TestConfig'
 ```
+
+#### Acceptance Tests
+
+**Warning:** The acceptance tests create/destroy/modify *real resources*,
+which may incur real costs in some cases. In the presence of a bug,
+it is technically possible that broken backends could leave dangling
+data behind. Therefore, please run the acceptance tests at your own risk.
+At the very least, we recommend running them in their own private
+account for whatever backend you're testing.
+
+Acceptance tests require the following environment variables.
+```sh
+export VAULT_ACC_TEST_ROLE_ARN=<myrolearn>
+export VAULT_ACC_TEST_ACCESS_KEY_ID=<myaccesskeyid>
+export VAULT_ACC_TEST_SECRET_KEY=<mysecretkey>
+export VAULT_ACC=1
+```
+
+To run the acceptance tests, invoke `make testacc`:
+
+```sh
+$ make testacc
+```
+

--- a/backend_test.go
+++ b/backend_test.go
@@ -35,8 +35,8 @@ const (
 	// The access key and secret given must be for a trusted actor and thus can
 	// assume the given role arn.
 	// Requires policy: AliyunSTSAssumeRoleAccess
-	envVarAccTestAccessKey = "VAULT_ACC_TEST_ACCESS_KEY"
-	envVarAccTestSecretKey = "VAULT_ACC_TEST_SECRET_KEY"
+	envVarAccTestAccessKeyID = "VAULT_ACC_TEST_ACCESS_KEY_ID"
+	envVarAccTestSecretKey   = "VAULT_ACC_TEST_SECRET_KEY"
 )
 
 var runAcceptanceTests = os.Getenv(envVarRunAccTests) == "1"
@@ -131,7 +131,7 @@ func TestBackend_Acceptance(t *testing.T) {
 		}(),
 		isAccTest: true,
 		arn:       arn,
-		accessKey: os.Getenv(envVarAccTestAccessKey),
+		accessKey: os.Getenv(envVarAccTestAccessKeyID),
 		secretKey: os.Getenv(envVarAccTestSecretKey),
 	}
 


### PR DESCRIPTION
# Overview
This PR enables a github action workflow to run the plugin acceptance tests. We do the following:
- add a `make testacc` make target
- update the README on steps to manually run the acceptance tests
- add a [acc-tests.yaml](https://github.com/hashicorp/vault-plugin-auth-alicloud/compare/add-ci-acc-tests?expand=1#diff-d8911d58018995b0076267be89bd3e997bce15cfbe4f28e0f5c37d032ba7befa) file that sets Github secrets as environment variables to be used for the acceptance tests

# Related Issues/Pull Requests
- https://github.com/hashicorp/vault-plugin-auth-alicloud/pull/63
