### PR TITLE
acc tests: skip dependabot

### DIFF
--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   run-acc-tests:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     env:
       VAULT_AUTH_ACC_TEST_ROLE_ARN: ${{ secrets.VAULT_AUTH_ACC_TEST_ROLE_ARN }}


### PR DESCRIPTION
Skip dependabot PRs for acc test workflows because dependabot can't access GH secrets.