### PR TITLE
Added missing OpenAPI metadata to the API endpoints

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -70,7 +70,7 @@ has included a signature.`,
 								Description: "Token policies associated with the issued token.",
 							},
 							"metadata": {
-								Type: framework.TypeMap,
+								Type:        framework.TypeMap,
 								Description: "Metadata associated with the issued token, including account_id, user_id, role_id, arn, identity_type, principal_id, request_id, and role_name.",
 							},
 							"lease_duration": {

--- a/path_login.go
+++ b/path_login.go
@@ -45,9 +45,81 @@ If a matching role is not found, login fails.`,
 has included a signature.`,
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation:      b.pathLoginUpdate,
-			logical.ResolveRoleOperation: b.pathLoginResolveRole,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Summary:  "Authenticate with AliCloud.",
+				Callback: b.pathLoginUpdate,
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"client_token": {
+								Type:        framework.TypeString,
+								Description: "Token used for authenticated requests.",
+							},
+							"accessor": {
+								Type:        framework.TypeString,
+								Description: "Accessor for the issued token.",
+							},
+							"policies": {
+								Type:        framework.TypeSlice,
+								Description: "Policies associated with the issued token.",
+							},
+							"token_policies": {
+								Type:        framework.TypeSlice,
+								Description: "Token policies associated with the issued token.",
+							},
+							"metadata": {
+								Type: framework.TypeMap,
+								Description: "Metadata associated with the issued token, including account_id, user_id, role_id, arn, identity_type, principal_id, request_id, and role_name.",
+							},
+							"lease_duration": {
+								Type:        framework.TypeInt,
+								Description: "Lease duration of the issued token in seconds.",
+							},
+							"renewable": {
+								Type:        framework.TypeBool,
+								Description: "Whether the issued token is renewable.",
+							},
+							"entity_id": {
+								Type:        framework.TypeString,
+								Description: "Entity ID associated with the issued token.",
+							},
+							"token_type": {
+								Type:        framework.TypeString,
+								Description: "Token type issued by this login.",
+							},
+							"orphan": {
+								Type:        framework.TypeBool,
+								Description: "Whether the issued token is an orphan token.",
+							},
+							"mfa_requirement": {
+								Type:        framework.TypeMap,
+								Description: "MFA requirements associated with the issued token.",
+							},
+							"num_uses": {
+								Type:        framework.TypeInt,
+								Description: "Number of permitted uses for the issued token.",
+							},
+						},
+					}},
+				},
+			},
+			logical.ResolveRoleOperation: &framework.PathOperation{
+				Summary:  "Resolve the role used for login.",
+				Callback: b.pathLoginResolveRole,
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"role": {
+								Type:        framework.TypeString,
+								Description: "Resolved role name.",
+							},
+						},
+					}},
+				},
+			},
 		},
 		HelpSynopsis:    pathLoginSyn,
 		HelpDescription: pathLoginDesc,

--- a/path_role.go
+++ b/path_role.go
@@ -14,6 +14,73 @@ import (
 )
 
 func pathRole(b *backend) *framework.Path {
+	roleResponseFields := map[string]*framework.FieldSchema{
+		"arn": {
+			Type:        framework.TypeString,
+			Description: "ARN of the RAM role bound to this role.",
+		},
+		"policies": {
+			Type:        framework.TypeSlice,
+			Description: "Token policies associated with this role.",
+		},
+		"ttl": {
+			Type:        framework.TypeInt,
+			Description: "Token TTL in seconds associated with this role.",
+		},
+		"max_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Maximum token TTL in seconds associated with this role.",
+		},
+		"period": {
+			Type:        framework.TypeInt,
+			Description: "Token period in seconds associated with this role.",
+		},
+		"bound_cidrs": {
+			Type:        framework.TypeSlice,
+			Description: "CIDR blocks associated with this role.",
+		},
+		"token_bound_cidrs": {
+			Type:        framework.TypeSlice,
+			Description: "CIDR blocks bound to tokens issued by this role.",
+		},
+		"token_explicit_max_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Explicit maximum token TTL in seconds associated with this role.",
+		},
+		"token_max_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Maximum token TTL in seconds associated with this role.",
+		},
+		"token_no_default_policy": {
+			Type:        framework.TypeBool,
+			Description: "Whether tokens issued by this role omit the default policy.",
+		},
+		"token_period": {
+			Type:        framework.TypeInt,
+			Description: "Token period in seconds associated with this role.",
+		},
+		"token_policies": {
+			Type:        framework.TypeSlice,
+			Description: "Token policies associated with this role.",
+		},
+		"token_type": {
+			Type:        framework.TypeString,
+			Description: "Token type issued by this role.",
+		},
+		"token_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Token TTL in seconds associated with this role.",
+		},
+		"token_num_uses": {
+			Type:        framework.TypeInt,
+			Description: "Number of permitted uses for tokens issued by this role.",
+		},
+		"alias_metadata": {
+			Type:        framework.TypeMap,
+			Description: "Alias metadata associated with tokens issued by this role.",
+		},
+	}
+
 	p := &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("role"),
 		DisplayAttrs: &framework.DisplayAttributes{
@@ -56,11 +123,35 @@ func pathRole(b *backend) *framework.Path {
 			},
 		},
 		ExistenceCheck: b.operationRoleExistenceCheck,
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.operationRoleCreateUpdate,
-			logical.UpdateOperation: b.operationRoleCreateUpdate,
-			logical.ReadOperation:   b.operationRoleRead,
-			logical.DeleteOperation: b.operationRoleDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Summary:  "Create a role.",
+				Callback: b.operationRoleCreateUpdate,
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No content."}},
+				},
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Summary:  "Update a role.",
+				Callback: b.operationRoleCreateUpdate,
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No content."}},
+				},
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Summary:  "Read a role.",
+				Callback: b.operationRoleRead,
+				Responses: map[int][]framework.Response{
+					200: {{Description: "OK", Fields: roleResponseFields}},
+				},
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Summary:  "Delete a role.",
+				Callback: b.operationRoleDelete,
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No content."}},
+				},
+			},
 		},
 		HelpSynopsis:    pathRoleSyn,
 		HelpDescription: pathRoleDesc,
@@ -78,8 +169,22 @@ func pathListRole(b *backend) *framework.Path {
 			OperationVerb:   "list",
 			OperationSuffix: "auth-roles",
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.operationRoleList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Summary:  "List all roles.",
+				Callback: b.operationRoleList,
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "Role names.",
+							},
+						},
+					}},
+				},
+			},
 		},
 		HelpSynopsis:    pathListRolesHelpSyn,
 		HelpDescription: pathListRolesHelpDesc,
@@ -94,8 +199,22 @@ func pathListRoles(b *backend) *framework.Path {
 			OperationVerb:   "list",
 			OperationSuffix: "auth-roles2",
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.operationRoleList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Summary:  "List all roles.",
+				Callback: b.operationRoleList,
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "Role names.",
+							},
+						},
+					}},
+				},
+			},
 		},
 		HelpSynopsis:    pathListRolesHelpSyn,
 		HelpDescription: pathListRolesHelpDesc,


### PR DESCRIPTION
# Overview
Who the change affects or is for (stakeholders)?
The change affects mainly people who use the Vault's UI. With the added fields, they can better understand the endpoints in the alicloud auth plugin.

What is the change?
I added the missing operation summary, path descriptions, and proper typed response schema for the alicloud auth plugin. I edited path_role.go and path_login.go

Why is the change needed?
The change is needed because many of the plugins in vault were missing path descriptions, operation summaries, and typed response schemas. Many of the response schemas had a bare 200 Description OK response, which is not sufficient.

How does this change affect the user experience (if at all)?
When someone uses the Vault UI, they are able to understand the vault plugins better because they have a detailed description of what the endpoint does and meaningful response schema. With the response schema, they can understand what the endpoint returns.


# Design of Change
How was this change implemented?

I developed an AI skill that automatically adds the HelpSynopsis, Summary, and Response Fields. The Help Synopsis field helps with the path descriptions, and the Help Description and path name are used to come up with the Help Synopsis field. The path name, Operation Prefix, and Operation Suffix are used to come up with the operation summary. For the response schema, the AI skill is able to detect what data types are being added to the response data map, and the skill generates a response schema with those data types. For methods that return a nil, nil, a 204 response code is added.
